### PR TITLE
Fix typo (`nn.Layernorm` -> `nn.LayerNorm`)

### DIFF
--- a/alphafold3/model.py
+++ b/alphafold3/model.py
@@ -69,7 +69,7 @@ class AlphaFold3(nn.Module):
         )
 
         # Norm
-        self.norm = nn.Layernorm(dim)
+        self.norm = nn.LayerNorm(dim)
 
     def forward(
         self,


### PR DESCRIPTION
See the title. The example doesn't work at the moment because of a typo in model.py. I fixed the typo. 