### PR TITLE
Add Dockerfile (PyTorch base image)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,23 @@
+
+FROM pytorch/pytorch:2.3.0-cuda12.1-cudnn8-runtime
+
+## Add System Dependencies
+RUN apt-get update \
+    && DEBIAN_FRONTEND=noninteractive apt-get install --no-install-recommends -y \
+        build-essential \
+        git \
+        wget \
+    && rm -rf /var/lib/apt/lists/* \
+    && apt-get autoremove -y \
+    && apt-get clean
+
+## Change working directory
+RUN mkdir -p /app/alphafold
+WORKDIR /app/alphafold
+
+## Install the AlphaFold3 package + requirements
+COPY . .
+RUN python -m pip install -r requirements.txt \
+    && python -m pip install git+https://github.com/aqlaboratory/openfold \
+    && python -m pip install .
+

--- a/README.md
+++ b/README.md
@@ -87,6 +87,16 @@ output = model(x, y)
 print(output.shape)
 ```
 
+# Docker
+A basic PyTorch image is provided that includes the dependencies to run this code.
+
+```bash
+## Build the image
+docker build -t af3 .
+
+## Run the image (with GPUs)
+docker run  --gpus all -it af3
+```
 
 # Citation
 ```bibtex


### PR DESCRIPTION
This PR includes a Dockerfile for running the AF3 library in a container. The included Dockerfile uses a PyTorch base image and installs from the repo's contents (rather than from PyPI).